### PR TITLE
Enable CraftTweaker support

### DIFF
--- a/src/main/java/singulariteam/eternalsingularity/proxy/CommonProxy.java
+++ b/src/main/java/singulariteam/eternalsingularity/proxy/CommonProxy.java
@@ -57,7 +57,7 @@ public class CommonProxy {
 		}
 		ForgeRegistries.ITEMS.register(EternalSingularityItem.instance);
 		ForgeRegistries.ITEMS.register(compoundSingularityItem = new CompoundSingularityItem(81));
-		if (Loader.isModLoaded("MineTweaker3"))
+		if (Loader.isModLoaded("crafttweaker"))
 			EternalRecipeTweaker.init();
 	}
 


### PR DESCRIPTION
CraftTweaker2 doesn't use the MineTweaker3 mod id, it uses crafttweaker